### PR TITLE
BUG, cannot add bare metal in production

### DIFF
--- a/src/mist/io/views.py
+++ b/src/mist/io/views.py
@@ -207,8 +207,8 @@ def add_backend(request):
 
     user = user_from_request(request)
     backend_id = methods.add_backend(
-        user, title, provider, apikey, apisecret, apiurl, tenant_name,
-        machine_hostname, machine_key, machine_user
+        user, title, provider, apikey, apisecret, apiurl, tenant_name=tenant_name,
+        machine_hostname=machine_hostname, machine_key=machine_key, machine_user=machine_user
     )
     backend = user.backends[backend_id]
     return {


### PR DESCRIPTION
When adding bare metal we got Keypair Not Found: root, where root was the username we provided

The reason is that params where not given in the right order to methods.add_backend

Made them in the form of `tenant_name=tenant_name` to ensure that if we screw with the order again it will not cause an exception.

Run Custom io tests and passed.
