### PR TITLE
Error handling improvements

### DIFF
--- a/src/mist/io/exceptions.py
+++ b/src/mist/io/exceptions.py
@@ -36,7 +36,8 @@ class MistError(Exception):
     the message provided during exception initialization, if provided.
 
     """
-    msg = "Error"
+    msg = "Mist Error"
+    http_code = 500
 
     def __init__(self, msg=None):
         msg = "%s: %s" % (self.msg, msg) if msg is not None else self.msg
@@ -46,6 +47,7 @@ class MistError(Exception):
 # BAD REQUESTS (translated as 400 in views)
 class BadRequestError(MistError):
     msg = "Bad Request"
+    http_code = 400
 
 
 class RequiredParameterMissingError(BadRequestError):
@@ -63,6 +65,7 @@ class KeyValidationError(BadRequestError):
 # UNAUTHORIZED (translated as 401 in views)
 class UnauthorizedError(MistError):
     msg = "Not authorized"
+    http_code = 401
 
 
 class BackendUnauthorizedError(UnauthorizedError):
@@ -76,16 +79,19 @@ class MachineUnauthorizedError(UnauthorizedError):
 # PAYMENT REQUIRED (translated as 402 in views)
 class PaymentRequiredError(MistError):
     msg = "Payment required"
+    http_code = 402
 
 
 # FORBIDDEN (translated as 403 in views)
 class ForbiddenError(MistError):
     msg = "Forbidden"
+    http_code = 403
 
 
 # NOT FOUND (translated as 404 in views)
 class NotFoundError(MistError):
     msg = "Not Found"
+    http_code = 404
 
 
 class BackendNotFoundError(NotFoundError, KeyError):
@@ -103,11 +109,13 @@ class MachineNotFoundError(NotFoundError, KeyError):
 # NOT ALLOWED (translated as 405 in views)
 class MethodNotAllowedError(MistError):
     msg = "Method Not Allowed"
+    http_code = 405
 
 
 # CONFLICT (translated as 409 in views)
 class ConflictError(MistError):
     msg = "Conflict"
+    http_code = 409
 
 
 class BackendExistsError(ConflictError):
@@ -125,6 +133,7 @@ class KeypairExistsError(ConflictError):
 # INTERNAL ERROR (translated as 500 in views)
 class InternalServerError(MistError):
     msg = "Internal Server Error"
+    http_code = 500
 
 
 class MachineCreationError(InternalServerError):
@@ -134,6 +143,7 @@ class MachineCreationError(InternalServerError):
 # SERVICE UNAVAILABLE (translated as 503 in views)
 class ServiceUnavailableError(MistError):
     msg = "Service unavailable"
+    http_code = 503
 
 
 class BackendUnavailableError(ServiceUnavailableError):


### PR DESCRIPTION
- Add http_code attribute to MistError subclasses
  The mapping of MistError's to HTTP responses is now done
  in the exception's definition.
- Improve and clean up exception handler.
- Make exception handler gracefully handle generic exceptions too.
