### PR TITLE
Fill area under graph line in d3 graphs.

### DIFF
--- a/src/mist/io/static/css/monitoring.css
+++ b/src/mist/io/static/css/monitoring.css
@@ -173,7 +173,13 @@
     fill: white;
 }
 
-.graph path {
+.graph .valueArea {
+    fill: #6CE0BA;
+    stroke-width: 0;
+    opacity: 0.25;
+}
+
+.graph .valueLine {
     stroke: #6CE0BA;
     stroke-width: 3;
     fill: none;


### PR DESCRIPTION
An extra SVG area element was added to the graphs that fills
the area underneath the graph line in monitoring graphs. The
existing SVG line element is also used to stroke the top side
of the area (we could use stroke for the area element and get
rid of the line element but that would stroke all around the
area, not just on top and using two elements seems to be the
standard way to go here).
