### PR TITLE
Change default user image (when user is logged in)

### DIFF
--- a/src/mist/io/static/js/app/views/user_menu.js
+++ b/src/mist/io/static/js/app/views/user_menu.js
@@ -16,7 +16,7 @@ define('app/views/user_menu', ['text!app/templates/user_menu.html', 'ember'],
             template: Ember.Handlebars.compile(user_menu_html),
             //TODO: change the logo_splash.png to user.png
             gravatarURL: EMAIL && ('https://www.gravatar.com/avatar/' + md5(EMAIL) + '?d=' +
-                  encodeURIComponent('https://mist.io/resources/logo_splash.png') +'&s=36'),
+                  encodeURIComponent('https://mist.io/resources/images/user.png') +'&s=36'),
 
 
             /**


### PR DESCRIPTION
It used to be the huge mist logo when developing mist_upgrade. Now it is the same as the icon when user is not logged in
