### PR TITLE
Prevent sliders from closing on swipe

### DIFF
--- a/src/mist/io/static/js/app/templates/backend_add.html
+++ b/src/mist/io/static/js/app/templates/backend_add.html
@@ -1,4 +1,5 @@
 <div id="add-backend-panel"
+     data-swipe-close="false"
      class="side-panel"
      data-role="panel"
      data-position="right"

--- a/src/mist/io/static/js/app/templates/machine_add.html
+++ b/src/mist/io/static/js/app/templates/machine_add.html
@@ -1,4 +1,5 @@
-<div id="create-machine-panel" 
+<div id="create-machine-panel"
+     data-swipe-close="false"
      class="side-panel" 
      data-role="panel" 
      data-position="right" 

--- a/src/mist/io/static/js/app/templates/machine_keys.html
+++ b/src/mist/io/static/js/app/templates/machine_keys.html
@@ -1,4 +1,5 @@
 <div id="machine-keys-panel"
+    data-swipe-close="false"
     class="side-panel"
     data-role="panel"
     data-position="right"


### PR DESCRIPTION
Sliders would close on swipe and this was not acceptable in mobile devices.
Added --> data-swipe-close="false" to prevent them from closing
