### PR TITLE
Small fix for the tests to try to flip the right switch

### DIFF
--- a/src/mist/io/tests/features/steps/backends.py
+++ b/src/mist/io/tests/features/steps/backends.py
@@ -125,7 +125,7 @@ def rename_backend(context, new_name):
 
 @when(u'I flip the backend switch')
 def backends_flip_switch(context):
-    context.browser.find_by_css('a.ui-slider-handle').click()
+    context.browser.find_by_css('#edit-backend-popup').find_by_css('a.ui-slider-handle').click()
     #context.browser.execute_script("$('#backend-toggle').val('%s' == '1' ? '0' : '1').slider('refresh').trigger('change')" % state)
     #sleep(time_fast)
 


### PR DESCRIPTION
The previous code was: 

context.browser.find_by_css('a.ui-slider-handle').click() 

but after adding a second ui-slider in the Openstack Advanced settings, behave tried to click that sometimes, depending on which got loaded first. So a change was necessary...
