### PR TITLE
Graphs value popup & selector line

### DIFF
--- a/src/mist/io/static/js/app/views/monitoring.js
+++ b/src/mist/io/static/js/app/views/monitoring.js
@@ -897,7 +897,13 @@ define('app/views/monitoring', ['app/views/templated','ember'],
                         var clearUpdatePopUp = function() {
 
                             isVisible = false;
-                            $(this).find('.selectorLine').hide(0);
+
+                            // We check for none display before we hide because jquery will 'show' the element instead
+                            // (possible jquery bug ?)
+                            var selectorLine = $(this).find('.selectorLine');
+                            if($(selectorLine).css('display') != 'none')
+                                $(selectorLine).hide(0);
+
                             $("#GraphsArea").find('.valuePopUp').hide(0);
 
                             // Clear Interval


### PR DESCRIPTION
When cursor is near the right edge of the window value of the popup is not visible. 
This change makes the popup to appear at the left side of the cursor when it reaches the right edge.

Also sometimes the value line selector is visible at the left side of the graphs value area. This is now fixed.
