### PR TITLE
Remove forgotten 'return' statement.

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -795,7 +795,6 @@ def _create_machine_ec2(conn, key_name, private_key, public_key, script,
         log.info("Attempting to create security group")
         conn.ex_create_security_group(name=name, description=description)
         conn.ex_authorize_security_group_permissive(name=name)
-        return True
     except Exception as exc:
         if 'Duplicate' in exc.message:
             log.info('Security group already exists, not doing anything.')


### PR DESCRIPTION
Probably left out from debugging, we returned True after
succesful sec-group creation when creating new ec2 machine.
