### PR TITLE
Do not set machine as probed when associating a key

### DIFF
--- a/src/mist/io/static/js/app/controllers/keys.js
+++ b/src/mist/io/static/js/app/controllers/keys.js
@@ -289,7 +289,6 @@ define(['app/models/key'],
                 Ember.run(this, function() {
                     this.getKey(keyId).machines.pushObject([machine.backend.id, machine.id]);
                     machine.set('keysCount', this.getMachineKeysCount(machine));
-                    machine.set('probed', true);
                     machine.probe(keyId);
                     this.trigger('onKeyAssociate');
                 });


### PR DESCRIPTION
Do not set machine as probed when associating a key because it breaks when machines get created too quickly
