### PR TITLE
Gce libcloud update

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -1177,8 +1177,9 @@ def _create_machine_gce(conn, key_name, private_key, public_key,
     """
     key = public_key.replace('\n', '')
 
-    metadata = {'items': [{'key': 'startup-script', 'value': script},
-                          {'key': 'sshKeys', 'value': 'user:%s' % key}]}
+    metadata = {'startup-script': script,
+                'sshKeys': 'user:%s' % key}
+    #metadata for ssh user, ssh key and script to deploy 
     with get_temp_file(private_key) as tmp_key_path:
         try:
             node = conn.create_node(


### PR DESCRIPTION
Merge pull request after libcloud is merged to 0.15
fixes node creation metadata in GCE, since libcloud driver has changed
