### PR TITLE
define log before import settings in celery_app

### DIFF
--- a/src/mist/io/celery_app.py
+++ b/src/mist/io/celery_app.py
@@ -3,15 +3,6 @@ from __future__ import absolute_import
 
 from celery import Celery
 
-# Parse user defined settings from settings.py in the top level project dir
-settings = {}
-try:
-    execfile("settings.py", settings)
-except IOError:
-    log.warning("No settings.py file found.")
-except Exception as exc:
-    log.error("Error parsing settings py: %r", exc)
-
 try:
     from mist.core import config
 except ImportError:
@@ -22,6 +13,15 @@ logging.basicConfig(level=config.PY_LOG_LEVEL,
                     format=config.PY_LOG_FORMAT,
                     datefmt=config.PY_LOG_FORMAT_DATE)
 log = logging.getLogger(__name__)
+
+# Parse user defined settings from settings.py in the top level project dir
+settings = {}
+try:
+    execfile("settings.py", settings)
+except IOError:
+    log.warning("No settings.py file found.")
+except Exception as exc:
+    log.error("Error parsing settings py: %r", exc)
 
 
 app = Celery(


### PR DESCRIPTION
otherwise nothing works if settings.py isn't defined
