### PR TITLE
allow the resize action, which resizes node to another plan

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -605,6 +605,11 @@ def get_machine_actions(machine_from_api, conn):
         can_reboot = True
         can_tag = False
 
+    if conn.type in [Provider.LINODE]:
+        if machine_from_api.state is NodeState.PENDING:
+        #after resize, node gets to pending mode, needs to be started
+            can_start = True
+        
     if conn.type is Provider.GCE:
         can_start = False
         can_stop = False
@@ -1207,13 +1212,13 @@ def _create_machine_linode(conn, key_name, private_key, public_key, script,
     return node
 
 
-def _machine_action(user, backend_id, machine_id, action):
-    """Start, stop, reboot and destroy have the same logic underneath, the only
+def _machine_action(user, backend_id, machine_id, action, plan_id=None):
+    """Start, stop, reboot, resize and destroy have the same logic underneath, the only
     thing that changes is the action. This helper function saves us some code.
 
     """
 
-    actions = ('start', 'stop', 'reboot', 'destroy')
+    actions = ('start', 'stop', 'reboot', 'destroy', 'resize')
     if action not in actions:
         raise BadRequestError("Action '%s' should be one of %s" % (action,
                                                                    actions))
@@ -1263,6 +1268,8 @@ def _machine_action(user, backend_id, machine_id, action):
         elif action is 'stop':
             # In libcloud it is not possible to call this with machine.stop()
             conn.ex_stop_node(machine)
+        elif action is 'resize':
+            conn.ex_resize_node(node, plan_id)
         elif action is 'reboot':
             if bare_metal:
                 try:
@@ -1334,6 +1341,11 @@ def stop_machine(user, backend_id, machine_id):
 def reboot_machine(user, backend_id, machine_id):
     """Reboots a machine on a certain backend."""
     _machine_action(user, backend_id, machine_id, 'reboot')
+
+
+def resize_machine(user, backend_id, machine_id, plan_id):
+    """Resize a machine on an other plan."""
+    _machine_action(user, backend_id, machine_id, 'resize', plan_id=plan_id)
 
 
 @core_wrapper

--- a/src/mist/io/views.py
+++ b/src/mist/io/views.py
@@ -471,7 +471,9 @@ def machine_actions(request):
     user = user_from_request(request)
     params = request.json_body
     action = params.get('action', '')
-    if action in ('start', 'stop', 'reboot', 'destroy'):
+    plan_id = params.get('plan_id', '')
+    #plan_id is the id of the plan to resize
+    if action in ('start', 'stop', 'reboot', 'destroy', 'resize'):
         if action == 'start':
             methods.start_machine(user, backend_id, machine_id)
         elif action == 'stop':
@@ -480,6 +482,8 @@ def machine_actions(request):
             methods.reboot_machine(user, backend_id, machine_id)
         elif action == 'destroy':
             methods.destroy_machine(user, backend_id, machine_id)
+        elif action == 'resize':
+            methods.resize_machine(user, backend_id, machine_id, plan_id)
         ## return OK
         return methods.list_machines(user, backend_id)
     raise BadRequestError()


### PR DESCRIPTION
Currently Linode and Digital Ocean supports the resize action. Node and plan_id need be specifyed, which is the plan size the node will get after a succesfull resize.
