### PR TITLE
Closing shell: disconnect namespace, not socket

### DIFF
--- a/src/mist/io/static/js/app/controllers/machine_shell.js
+++ b/src/mist/io/static/js/app/controllers/machine_shell.js
@@ -131,7 +131,7 @@ define('app/controllers/machine_shell', ['app/models/command', 'ember' , 'term']
                 Ember.run.later(this, function () {
                     Mist.shell.emit('shell_close');
                     Mist.term.destroy();
-                    Mist.shell.socket.disconnect();
+                    Mist.shell.disconnect();
                     this._clear();
                     if (Terminal._textarea)
                         $(Terminal._textarea).hide();


### PR DESCRIPTION
Mist and Shell socketio namespaces are multiplexed over a single
websocket connection. When closing the shell, we want to disconnect
from the shell namespace, not disconnect the websocket. Currently,
closing the shell disconnects the websocket which is then immediately
reconnected (with a new session id). This commit fixes this behavor,
and subsequent shells will connect using the same websocket connection.
