### PR TITLE
Set isOpen property on machine shell controller

### DIFF
--- a/src/mist/io/static/js/app.js
+++ b/src/mist/io/static/js/app.js
@@ -1170,7 +1170,6 @@ function maxCharsInWidth (fontSize, width) {
     // Initialize testString to a number of chars that will "probably"
     // fit in width
     var textWidth = fontTest.text('t').width();
-    info(width, '/', textWidth, '=', width / textWidth);
     var testString = Array(parseInt(width / textWidth) + 5).join('t');
     textWidth = fontTest.text(testString).width();
 

--- a/src/mist/io/static/js/app/controllers/machine_shell.js
+++ b/src/mist/io/static/js/app/controllers/machine_shell.js
@@ -21,6 +21,7 @@ define('app/controllers/machine_shell', ['app/models/command', 'ember' , 'term']
             view: null,
             cols: null,
             rows: null,
+            isOpen: null,
             machine: null,
 
 
@@ -34,7 +35,10 @@ define('app/controllers/machine_shell', ['app/models/command', 'ember' , 'term']
             open: function (machine) {
 
                 this._clear();
-                this.set('machine', machine);
+                this.setProperties({
+                    machine: machine,
+                    isOpen: true,
+                });
 
                 // Get the first ipv4 public ip to connect to
                 machine.public_ips.forEach(function (ip) {
@@ -120,7 +124,6 @@ define('app/controllers/machine_shell', ['app/models/command', 'ember' , 'term']
 
 
             resize: function () {
-                info('resizing', this.cols, this.rows);
                 Mist.term.resize(this.cols, this.rows);
                 Mist.shell.emit('shell_resize',this.cols, this.rows);
             },
@@ -147,10 +150,13 @@ define('app/controllers/machine_shell', ['app/models/command', 'ember' , 'term']
 
             _clear: function () {
                 Ember.run(this, function () {
-                    this.set('cols', null);
-                    this.set('rows', null);
-                    this.set('machine', null);
-                    this.set('connected', null);
+                    this.setProperties({
+                        cols: null,
+                        rows: null,
+                        machine: null,
+                        connected: null,
+                        isOpen: false,
+                    });
                 });
             },
 


### PR DESCRIPTION
To prevent machine list view footer from sliding on top of "back" button
