### PR TITLE
python2.6 does not have dict comprehension

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -47,6 +47,9 @@ solve this you need to::
 
    ./bin/pip install setuptools --upgrade
 
+If you are using Python 2.6 you'll have to install ipython version 1, otherwise buildout will fail
+   ./bin/pip install ipython==1
+
 Deployment
 ----------
 

--- a/src/mist/io/dal.py
+++ b/src/mist/io/dal.py
@@ -354,7 +354,10 @@ class OODict(object):
         return type(self)(deepcopy(self._dict, memo))
 
     def as_dict(self):
-        return {key: self.__getattribute__(key) for key in self.keys()}
+        d = {}
+        for key in self.keys():
+            d[key] = self.__getattribute__(key)
+        return d
 
 
 class FieldsSequence(object):
@@ -475,7 +478,9 @@ class FieldsDict(FieldsSequence, MutableMapping):
             yield key
 
     def __repr__(self):
-        d = {key: self[key] for key in self.keys()}
+        d = {}
+        for key in self.keys():
+            d[key] = self[key]
         return "%s: %r" % (type(self), d)
 
     def __str__(self):

--- a/src/mist/io/inventory.py
+++ b/src/mist/io/inventory.py
@@ -51,8 +51,8 @@ class MistInventory(object):
                     'ansible_python_interpreter="/usr/bin/env python2"\n')
         ans_cfg = '[defaults]\nhostfile=./inventory\nhost_key_checking=False\n'
         files = {'ansible.cfg': ans_cfg, 'inventory': ans_inv}
-        files.update({'id_rsa/%s' % key_id: private_key
-                      for key_id, private_key in self.keys.items()})
+        for key_id, private_key in self.keys.items():
+             files.update({'id_rsa/%s' % key_id: private_key})
         return files
 
     def _list_machines(self, backend_id):


### PR DESCRIPTION
small fix for mist.io to support python 2.6 that is default for many systems (eg Centos 6.x)