### PR TITLE
Fix Mist.monitored_machines when Undefined

### DIFF
--- a/src/mist/io/static/js/app/views/home.js
+++ b/src/mist/io/static/js/app/views/home.js
@@ -59,6 +59,8 @@ define('app/views/home', ['app/views/mistscreen', 'app/models/graph'],
 
                 if (Mist.graphsController.isOpen)
                     return;
+                if ( ! Mist.monitored_machines )
+                    return;
 
                 var datasources = [];
                 var loadMetric = Mist.metricsController.getMetric('load.shortterm');


### PR DESCRIPTION
When not logged in from mist.io, monitored_machines is not returned and therefore Mist.monitored_machines is undefined. This breaks with `Cannot read property 'forEach'`.
