### PR TITLE
Gce update driver

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -1166,10 +1166,6 @@ def get_machine_actions(machine_from_api, conn, extra):
         # in libvirt a terminated machine can be started
             can_start = True
 
-    if conn.type is Provider.GCE:
-        can_start = False
-        can_stop = False
-
     if conn.type == Provider.LIBVIRT and extra.get('tags', {}).get('type', None) == 'hypervisor':
         # allow only reboot action for libvirt hypervisor
         can_stop = False

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -2173,17 +2173,6 @@ def list_images(user, backend_id, term=None):
                 image.name = config.EC2_IMAGES[conn.type].get(image.id, image.name)
             ec2_images += conn.list_images(ex_owner="amazon")
             ec2_images += conn.list_images(ex_owner="self")
-        elif conn.type == Provider.GCE:
-            # Currently not other way to receive all images :(
-            rest_images = conn.list_images()
-            for OS in config.GCE_IMAGES:
-                try:
-                    gce_images = conn.list_images(ex_project=OS)
-                    rest_images += gce_images
-                except:
-                    #eg ResourceNotFoundError
-                    pass
-            rest_images = [image for image in rest_images if not image.extra['deprecated']]
         elif conn.type == Provider.AZURE:
             # do not show Microsoft Windows images
             # from Azure's response we can't know which images are default

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -2173,6 +2173,12 @@ def list_images(user, backend_id, term=None):
                 image.name = config.EC2_IMAGES[conn.type].get(image.id, image.name)
             ec2_images += conn.list_images(ex_owner="amazon")
             ec2_images += conn.list_images(ex_owner="self")
+        elif conn.type == Provider.GCE:
+            rest_images = conn.list_images()
+            for gce_image in rest_images:
+                if gce_image.extra.get('licenses'):
+                    gce_image.extra['licenses'] = None
+            # GCE has some objects in extra so we make sure they are not passed
         elif conn.type == Provider.AZURE:
             # do not show Microsoft Windows images
             # from Azure's response we can't know which images are default

--- a/src/mist/io/static/js/app/models/backend.js
+++ b/src/mist/io/static/js/app/models/backend.js
@@ -56,6 +56,11 @@ define('app/models/backend', ['app/controllers/machines', 'app/controllers/image
                     .indexOf(this.provider) > -1;
             }.property('provider'),
 
+            requiresNetworkOnCreation: function () {
+                return  ['openstack', 'vcloud', 'indonesian_vcloud']
+                    .indexOf(this.provider) > -1;
+            }.property('provider'),
+
             isLibvirt: function () {
                 return this.get('provider') == 'libvirt';
             }.property('provider'),

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -180,7 +180,7 @@ define('app/views/machine_add', ['app/views/templated', 'ember'],
                     $('#create-machine-panel .docker .ui-checkbox').addClass('ui-state-disabled');
                     $('#create-machine-network .ui-collapsible').addClass('ui-state-disabled');
 
-                    if (backend.get('hasNetworks')) {
+                    if (backend.get('requiresNetworkOnCreation')) {
                         if (backend.networks.content.length > 0) {
                             $('#create-machine-network').show();
                             $('label[for=create-machine-script]').text('Script:');


### PR DESCRIPTION
simplify the listing of GCE images, remove the networks section for create machine wizard (redundant)
First needs merge for https://github.com/mistio/libcloud/pull/27 which fixes issues with invalid errors when providing wrong creds

