### PR TITLE
make it more verbose to run the monitor script, for sudoers with pass…

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -3920,7 +3920,7 @@ def undeploy_collectd(user, backend_id, machine_id):
 
 def get_deploy_collectd_command_unix(uuid, password, monitor):
     url = "https://github.com/mistio/deploy_collectd/raw/master/local_run.py"
-    cmd = "wget -O - %s | $(command -v sudo) python - %s %s" % (url, uuid, password)
+    cmd = "wget -O mist_collectd.py %s && $(command -v sudo) python mist_collectd.py %s %s" % (url, uuid, password)
     if monitor != 'monitor1.mist.io':
         cmd += " -m %s" % monitor
     return cmd


### PR DESCRIPTION
the current command when run from a sudoer user with password, will seem it has hunged right after it has wget-ed the file. Unless the user types something, or realizes what the command does, they will think it has hunged. This PR makes it ask for the sudo pass right after wget downloads the file