### PR TITLE
pass no ssh arg on disable monitoring

### DIFF
--- a/src/mist/io/static/js/app/controllers/monitoring.js
+++ b/src/mist/io/static/js/app/controllers/monitoring.js
@@ -75,7 +75,7 @@ define('app/controllers/monitoring', ['app/models/graph', 'app/models/metric', '
             },
 
 
-            disableMonitoring: function(machine, callback) {
+            disableMonitoring: function(machine, callback, noSsh) {
 
                 var that = this;
                 machine.set('disablingMonitoring', true);
@@ -86,6 +86,7 @@ define('app/controllers/monitoring', ['app/models/graph', 'app/models/metric', '
 
                 Mist.ajax.POST(url, {
                     'action': 'disable',
+                    'no_ssh': noSsh || false,
                     'name': machine.name || machine.id,
                     'public_ips': machine.public_ips || [],
                     'dns_name': machine.extra.dns_name || 'n/a',

--- a/src/mist/io/static/js/app/views/machine_monitoring.js
+++ b/src/mist/io/static/js/app/views/machine_monitoring.js
@@ -181,13 +181,14 @@ define('app/views/machine_monitoring',
 
                         // Disable monitoring after a while to enalbe
                         // smoothScroll to scroll to top
+
                         Ember.run.later(function () {
                             Mist.monitoringController
                                 .disableMonitoring(machine,
                                     function (success) {
                                         if (success)
                                             Mist.graphsController.close();
-                                    }
+                                    }, !machine.probed
                                 );
                         }, 200);
                     }


### PR DESCRIPTION
passes a no_ssh arg on disable monitoring so for not probed machines it will not try to run the ansible disable monitoring playbook (and end up on error)