### PR TITLE
Add buildout package dependency for Fedora/RHEL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ For vSphere support, you should install pyvmomi library::
 
 In Red Hat based systems the following packages need to be installed::
 
-    sudo yum install git python-virtualenv python-dev erlang pcre python-lxml gcc libxml2 libxml2-python libxml2-devel
+    sudo yum install git python-virtualenv python-dev erlang pcre python-lxml gcc libxml2 libxml2-python libxml2-devel python-zc-buildout
 
 For openSUSE distibution, you'll have to additionally install::
 


### PR DESCRIPTION
I needed to install python-zc-buildout to get /usr/bin/buildout on RHEL/CentOS.  Verified to be accurate on :
* RHEL-6.5 (final)
* Fedora 21

A quick test against CentOS 5.3 (final) suggests that this isn't in the stock repos, but it was tested against a VM that has RPM issues, so take it with a grain of salt.