### PR TITLE
add support for cloudinit for GCE/Rackspace/Vultr and also cloudinit validation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,6 +125,14 @@ module.exports = function(grunt) {
                     force: true
                 }
             },
+            yamljs: {
+                target: '../node_modules/yamljs/',
+                link: 'dist/yamljs',
+                options: {
+                    overwrite: true,
+                    force: true
+                }
+            },
             images: {
                 target: '../src/mist/io/static/images',
                 link: 'dist/images',
@@ -207,6 +215,7 @@ module.exports = function(grunt) {
 		'symlink:images',
 		'symlink:fonts',
 		'symlink:states',
+		'symlink:yamljs',
 		'requirejs',
 		'symlink:mistjs',
 		'symlink:mistcss',

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "grunt-contrib-requirejs": "^0.4.4",
     "grunt-ember-templates": "^0.5.0",
     "grunt-symbolic-link": "^0.3.1",
-    "handlebars": "^2.0.0"
+    "handlebars": "^2.0.0",
+    "yamljs": "^0.2.4"
   },
   "devDependencies": {
     "grunt-string-replace": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "yamljs": "^0.2.4"
   },
   "devDependencies": {
-    "grunt-string-replace": "^1.2.0",
-    "yamljs": "^0.2.4"
+    "grunt-string-replace": "^1.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "yamljs": "^0.2.4"
   },
   "devDependencies": {
-    "grunt-string-replace": "^1.2.0"
+    "grunt-string-replace": "^1.2.0",
+    "yamljs": "^0.2.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -1705,7 +1705,7 @@ def create_machine(user, cloud_id, key_id, machine_name, location_id,
                                          size, location)
     elif conn.type == Provider.VULTR:
         node = _create_machine_vultr(conn, public_key, machine_name, image,
-                                         size, location, cloud_init)
+                                         size, location)
     elif conn.type == Provider.PACKET:
         node = _create_machine_packet(conn, public_key, machine_name, image,
                                          size, location, cloud_init, project_id)
@@ -2272,7 +2272,7 @@ def _create_machine_packet(conn, public_key, machine_name, image, size, location
     return node
 
 
-def _create_machine_vultr(conn, public_key, machine_name, image, size, location, cloud_init):
+def _create_machine_vultr(conn, public_key, machine_name, image, size, location):
     """Create a machine in Vultr.
 
     Here there is no checking done, all parameters are expected to be
@@ -2304,8 +2304,7 @@ def _create_machine_vultr(conn, public_key, machine_name, image, size, location,
             size=size,
             image=image,
             location=location,
-            ssh_key=[server_key],
-            userdata=cloud_init
+            ssh_key=[server_key]
         )
     except Exception as e:
         raise MachineCreationError("Vultr, got exception %s" % e, e)

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -1705,7 +1705,7 @@ def create_machine(user, cloud_id, key_id, machine_name, location_id,
                                          size, location)
     elif conn.type == Provider.VULTR:
         node = _create_machine_vultr(conn, public_key, machine_name, image,
-                                         size, location)
+                                         size, location, cloud_init)
     elif conn.type == Provider.PACKET:
         node = _create_machine_packet(conn, public_key, machine_name, image,
                                          size, location, cloud_init, project_id)
@@ -2272,7 +2272,7 @@ def _create_machine_packet(conn, public_key, machine_name, image, size, location
     return node
 
 
-def _create_machine_vultr(conn, public_key, machine_name, image, size, location):
+def _create_machine_vultr(conn, public_key, machine_name, image, size, location, cloud_init):
     """Create a machine in Vultr.
 
     Here there is no checking done, all parameters are expected to be
@@ -2304,7 +2304,8 @@ def _create_machine_vultr(conn, public_key, machine_name, image, size, location)
             size=size,
             image=image,
             location=location,
-            ssh_key=[server_key]
+            ssh_key=[server_key],
+            userdata=cloud_init
         )
     except Exception as e:
         raise MachineCreationError("Vultr, got exception %s" % e, e)

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -1680,7 +1680,7 @@ def create_machine(user, cloud_id, key_id, machine_name, location_id,
                 size = size
                 break
         node = _create_machine_gce(conn, key_id, private_key, public_key,
-                                         machine_name, image, size, location)
+                                         machine_name, image, size, location, cloud_init)
     elif conn.type is Provider.SOFTLAYER:
         node = _create_machine_softlayer(conn, key_id, private_key, public_key,
                                          machine_name, image, size,
@@ -2412,7 +2412,7 @@ def _create_machine_vcloud(conn, machine_name, image, size, public_key, networks
 
 
 def _create_machine_gce(conn, key_name, private_key, public_key, machine_name,
-                        image, size, location):
+                        image, size, location, cloud_init):
     """Create a machine in GCE.
 
     Here there is no checking done, all parameters are expected to be
@@ -2424,6 +2424,8 @@ def _create_machine_gce(conn, key_name, private_key, public_key, machine_name,
     metadata = {#'startup-script': script,
                 'sshKeys': 'user:%s' % key}
     #metadata for ssh user, ssh key and script to deploy
+    if cloud_init:
+        metadata['startup-script'] = cloud_init
 
     with get_temp_file(private_key) as tmp_key_path:
         try:

--- a/src/mist/io/static/js/app.js
+++ b/src/mist/io/static/js/app.js
@@ -27,6 +27,7 @@ require.config({
         d3: '../dist/d3/d3.min',
         c3: '../dist/c3/c3.min',
         term: '../dist/term.js/src/term',
+        yamljs: '../dist/yamljs/dist/yaml.min',
         init: 'init',
         common: 'common',
         multiplex: 'multiplex'

--- a/src/mist/io/static/js/app/controllers/machine_add.js
+++ b/src/mist/io/static/js/app/controllers/machine_add.js
@@ -208,7 +208,7 @@ define('app/controllers/machine_add', ['ember', 'yamljs'],
                     try {
                         if ( ! (cloudInit.substring(0, 12) == "#!/bin/bash\n" || (YAML.parse(cloudInit) && cloudInit.substring(0, 13) == '#cloud-config'))) {
                             formReady = false;
-                            Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file', 4000);
+                            Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file (should start with #cloud-config)', 4000);
                         }
                     } catch (err) {
 
@@ -270,37 +270,9 @@ define('app/controllers/machine_add', ['ember', 'yamljs'],
                 }
             },
 
-            _validateCloudInit: function() {
-                var cloudInit = this.get('newMachineCloudInit').trim();
-                if (cloudInit) {
-                    var error = false;
-                    try {
-                        if ( ! (cloudInit.substring(0, 11) == '#!/bin/bash' || (YAML.parse(cloudInit) && cloudInit.substring(0, 13) == '#cloud-config'))) {
-                            error = true;
-                            console.log(1);
-                        }
-                    } catch (err) {
-                        error = true;
-                        console.log(2);
-                    }
-
-                    if (error) {
-                        console.log('error');
-                        this.set('invalidCloudInit', true);
-                        Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file (should start with #cloud-config)', 4000);
-                    } else {
-                        this.set('invalidCloudInit', false);
-                    }
-                }
-            },
-
             //
             //  Observers
             //
-
-            cloudInitObserver: function() {
-                // Ember.run.once(this, '_validateCloudInit');
-            }.observes('newMachineCloudInit'),
 
             providerObserver: function() {
                 Ember.run.once(this, '_selectUnique');

--- a/src/mist/io/static/js/app/controllers/machine_add.js
+++ b/src/mist/io/static/js/app/controllers/machine_add.js
@@ -1,4 +1,4 @@
-define('app/controllers/machine_add', ['ember'],
+define('app/controllers/machine_add', ['ember', 'yamljs'],
     /**
      *  Machine Add Controller
      *
@@ -67,7 +67,7 @@ define('app/controllers/machine_add', ['ember'],
 
                 if (providerName == 'NephoScale') {
                     var re = /^[0-9a-z_-]*$/;
-                    if ( machineName.length > 64 || !re.test(machineName)) {
+                    if (machineName.length > 64 || !re.test(machineName)) {
 
                         Mist.notificationController.timeNotify(
                             'Server name in NephoScale may have lower-case letters, numbers, hyphen (\'-\') and underscore (\'_\') characters, cannot exceed 64 ' +
@@ -76,12 +76,12 @@ define('app/controllers/machine_add', ['ember'],
                     }
                     if (machineSize.indexOf('CS025') > -1) {
                         if ((machineImage != 'Linux Ubuntu Server 10.04 LTS 64-bit') &&
-                            (machineImage !='Linux CentOS 6.2 64-bit')) {
+                            (machineImage != 'Linux CentOS 6.2 64-bit')) {
 
-                                Mist.notificationController.timeNotify(
-                                    'On CS025 size you can only create one of the two images: ' +
-                                    'Linux Ubuntu Server 10.04 LTS 64-bit or Linux CentOS 6.2 64-bit', 7000);
-                                return;
+                            Mist.notificationController.timeNotify(
+                                'On CS025 size you can only create one of the two images: ' +
+                                'Linux Ubuntu Server 10.04 LTS 64-bit or Linux CentOS 6.2 64-bit', 7000);
+                            return;
                         }
                     }
                 }
@@ -111,24 +111,24 @@ define('app/controllers/machine_add', ['ember'],
 
                 var that = this;
                 this.newMachineProvider.machines.newMachine(
-                        this.get('newMachineName'),
-                        this.get('newMachineImage'),
-                        this.get('newMachineSize'),
-                        this.get('newMachineLocation'),
-                        this.get('newMachineKey'),
-                        this.get('newMachineCloudInit'),
-                        this.get('newMachineScript'),
-                        this.get('newMachineProject'),
-                        this.get('newMachineMonitoring'),
-                        this.get('newMachineAssociateFloatingIp'),
-                        this.get('newMachineDockerEnvironment').trim(),
-                        this.get('newMachineDockerCommand'),
-                        this.get('newMachineScriptParams'),
-                        this.get('newMachineDockerPorts'),
-                        this.get('newMachineAzurePorts'),
-                        function(success, machine) {
-                            that._giveCallback(success, machine);
-                        }
+                    this.get('newMachineName'),
+                    this.get('newMachineImage'),
+                    this.get('newMachineSize'),
+                    this.get('newMachineLocation'),
+                    this.get('newMachineKey'),
+                    this.get('newMachineCloudInit'),
+                    this.get('newMachineScript'),
+                    this.get('newMachineProject'),
+                    this.get('newMachineMonitoring'),
+                    this.get('newMachineAssociateFloatingIp'),
+                    this.get('newMachineDockerEnvironment').trim(),
+                    this.get('newMachineDockerCommand'),
+                    this.get('newMachineScriptParams'),
+                    this.get('newMachineDockerPorts'),
+                    this.get('newMachineAzurePorts'),
+                    function(success, machine) {
+                        that._giveCallback(success, machine);
+                    }
                 );
 
                 this.close();
@@ -144,17 +144,27 @@ define('app/controllers/machine_add', ['ember'],
             //  Pseudo-Private Methods
             //
 
-             _clear: function() {
+            _clear: function() {
                 this.set('callback', null)
                     .set('newMachineName', '')
                     .set('newMachineCloudInit', '')
                     .set('newMachineScript', '')
                     .set('newMachineProject', '')
-                    .set('newMachineKey', {'title' : 'Select Key'})
-                    .set('newMachineSize', {'name' : 'Select Size'})
-                    .set('newMachineImage', {'name' : 'Select Image'})
-                    .set('newMachineLocation', {'name' : 'Select Location'})
-                    .set('newMachineProvider', {'title' : 'Select Provider'})
+                    .set('newMachineKey', {
+                        'title': 'Select Key'
+                    })
+                    .set('newMachineSize', {
+                        'name': 'Select Size'
+                    })
+                    .set('newMachineImage', {
+                        'name': 'Select Image'
+                    })
+                    .set('newMachineLocation', {
+                        'name': 'Select Location'
+                    })
+                    .set('newMachineProvider', {
+                        'title': 'Select Provider'
+                    })
                     .set('newMachineMonitoring', Mist.email ? true : false)
                     .set('newMachineAssociateFloatingIp', true)
                     .set('newMachineDockerEnvironment', '')
@@ -163,7 +173,7 @@ define('app/controllers/machine_add', ['ember'],
                     .set('newMachineDockerPorts', '')
                     .set('newMachineAzurePorts', '');
                 this.view.clear();
-             },
+            },
 
             _updateFormReady: function() {
                 var formReady = false;
@@ -182,15 +192,27 @@ define('app/controllers/machine_add', ['ember'],
                 }
 
                 if (this.newMachineProvider.provider == 'docker' && !this.view.dockerNeedScript) {
-                    if(! this.newMachineDockerCommand) {
+                    if (!this.newMachineDockerCommand) {
                         formReady = false;
                     }
                 }
 
                 if (this.newMachineImage.id &&
                     this.newMachineImage.get('isMist')) {
-                        if (!Mist.keysController.keyExists(this.newMachineKey.id))
+                    if (!Mist.keysController.keyExists(this.newMachineKey.id))
+                        formReady = false;
+                }
+
+                var cloudInit = this.get('newMachineCloudInit').trim();
+                if (cloudInit) {
+                    try {
+                        if ( ! (cloudInit.substring(0, 12) == "#!/bin/bash\n" || (YAML.parse(cloudInit) && cloudInit.substring(0, 13) == '#cloud-config'))) {
                             formReady = false;
+                            Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file', 4000);
+                        }
+                    } catch (err) {
+
+                    }
                 }
 
                 if (formReady && this.addingMachine) {
@@ -209,10 +231,18 @@ define('app/controllers/machine_add', ['ember'],
                     .set('newMachineCloudInit', '')
                     .set('newMachineScript', '')
                     .set('newMachineProject', '')
-                    .set('newMachineKey', {'title' : 'Select Key'})
-                    .set('newMachineSize', {'name' : 'Select Size'})
-                    .set('newMachineImage', {'name' : 'Select Image'})
-                    .set('newMachineLocation', {'name' : 'Select Location'})
+                    .set('newMachineKey', {
+                        'title': 'Select Key'
+                    })
+                    .set('newMachineSize', {
+                        'name': 'Select Size'
+                    })
+                    .set('newMachineImage', {
+                        'name': 'Select Image'
+                    })
+                    .set('newMachineLocation', {
+                        'name': 'Select Location'
+                    })
                     .set('newMachineAssociateFloatingIp', true)
                     .set('newMachineDockerEnvironment', '')
                     .set('newMachineDockerCommand', '')
@@ -240,9 +270,37 @@ define('app/controllers/machine_add', ['ember'],
                 }
             },
 
+            _validateCloudInit: function() {
+                var cloudInit = this.get('newMachineCloudInit').trim();
+                if (cloudInit) {
+                    var error = false;
+                    try {
+                        if ( ! (cloudInit.substring(0, 11) == '#!/bin/bash' || (YAML.parse(cloudInit) && cloudInit.substring(0, 13) == '#cloud-config'))) {
+                            error = true;
+                            console.log(1);
+                        }
+                    } catch (err) {
+                        error = true;
+                        console.log(2);
+                    }
+
+                    if (error) {
+                        console.log('error');
+                        this.set('invalidCloudInit', true);
+                        Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file', 4000);
+                    } else {
+                        this.set('invalidCloudInit', false);
+                    }
+                }
+            },
+
             //
             //  Observers
             //
+
+            cloudInitObserver: function() {
+                // Ember.run.once(this, '_validateCloudInit');
+            }.observes('newMachineCloudInit'),
 
             providerObserver: function() {
                 Ember.run.once(this, '_selectUnique');
@@ -251,12 +309,13 @@ define('app/controllers/machine_add', ['ember'],
             formObserver: function() {
                 Ember.run.once(this, '_updateFormReady');
             }.observes('newMachineKey',
-                       'newMachineName',
-                       'newMachineSize',
-                       'newMachineImage',
-                       'newMachineScript',
-                       'newMachineLocation',
-                       'newMachineProvider')
+                'newMachineName',
+                'newMachineSize',
+                'newMachineImage',
+                'newMachineScript',
+                'newMachineLocation',
+                'newMachineProvider',
+                'newMachineCloudInit')
         });
     }
 );

--- a/src/mist/io/static/js/app/controllers/machine_add.js
+++ b/src/mist/io/static/js/app/controllers/machine_add.js
@@ -287,7 +287,7 @@ define('app/controllers/machine_add', ['ember', 'yamljs'],
                     if (error) {
                         console.log('error');
                         this.set('invalidCloudInit', true);
-                        Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file', 4000);
+                        Mist.notificationController.timeNotify('Please start your cloud init script with #!/bin/bash or use a valid yaml configuration file (should start with #cloud-config)', 4000);
                     } else {
                         this.set('invalidCloudInit', false);
                     }

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -41,7 +41,7 @@ define('app/views/machine_add', ['app/views/controlled'],
 
             hasCloudInit: Ember.computed('Mist.machineAddController.newMachineProvider', function() {
                 var provider = Mist.machineAddController.newMachineProvider,
-                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce'];
+                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce', 'rackspace', 'rackspace_first_gen', 'vultr'];
                 return provider ? (provider.provider ? ((valids.indexOf(provider.provider) != -1 || provider.provider.indexOf('ec2') > -1) ? true : false) : false) : false;
             }),
 

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -51,8 +51,8 @@ define('app/views/machine_add', ['app/views/controlled'],
 
             hasLocation: function() {
                 var provider = Mist.machineAddController.newMachineProvider,
-                valids = ['docker', 'indonesiancloud', 'vcloud'];
-                return provider ? (provider.provider ? (valids.indexOf(provider.provider) != -1 ? false : true) : false) : false;
+                invalids = ['docker', 'indonesiancloud', 'vcloud'];
+                return provider ? (provider.provider ? ((invalids.indexOf(provider.provider) != -1 || provider.locations.model.length == 1) ? false : true) : false) : false;
             }.property('Mist.machineAddController.newMachineProvider'),
 
             hasNetworks: function() {

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -41,7 +41,7 @@ define('app/views/machine_add', ['app/views/controlled'],
 
             hasCloudInit: Ember.computed('Mist.machineAddController.newMachineProvider', function() {
                 var provider = Mist.machineAddController.newMachineProvider,
-                valids = ['openstack', 'azure', 'digitalocean', 'packet'];
+                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce'];
                 return provider ? (provider.provider ? ((valids.indexOf(provider.provider) != -1 || provider.provider.indexOf('ec2') > -1) ? true : false) : false) : false;
             }),
 

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -41,7 +41,7 @@ define('app/views/machine_add', ['app/views/controlled'],
 
             hasCloudInit: Ember.computed('Mist.machineAddController.newMachineProvider', function() {
                 var provider = Mist.machineAddController.newMachineProvider,
-                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce', 'rackspace', 'rackspace_first_gen'];
+                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce', 'rackspace', 'rackspace_first_gen', 'vultr'];
                 return provider ? (provider.provider ? ((valids.indexOf(provider.provider) != -1 || provider.provider.indexOf('ec2') > -1) ? true : false) : false) : false;
             }),
 

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -52,7 +52,7 @@ define('app/views/machine_add', ['app/views/controlled'],
             hasLocation: function() {
                 var provider = Mist.machineAddController.newMachineProvider,
                 valids = ['docker', 'indonesiancloud', 'vcloud'];
-                return provider ? (provider.provider ? ((valids.indexOf(provider.provider) != -1 || provider.locations.model.length == 1) ? false : true) : false) : false;
+                return provider ? (provider.provider ? (valids.indexOf(provider.provider) != -1 ? false : true) : false) : false;
             }.property('Mist.machineAddController.newMachineProvider'),
 
             hasNetworks: function() {

--- a/src/mist/io/static/js/app/views/machine_add.js
+++ b/src/mist/io/static/js/app/views/machine_add.js
@@ -41,7 +41,7 @@ define('app/views/machine_add', ['app/views/controlled'],
 
             hasCloudInit: Ember.computed('Mist.machineAddController.newMachineProvider', function() {
                 var provider = Mist.machineAddController.newMachineProvider,
-                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce', 'rackspace', 'rackspace_first_gen', 'vultr'];
+                valids = ['openstack', 'azure', 'digitalocean', 'packet', 'gce', 'rackspace', 'rackspace_first_gen'];
                 return provider ? (provider.provider ? ((valids.indexOf(provider.provider) != -1 || provider.provider.indexOf('ec2') > -1) ? true : false) : false) : false;
             }),
 

--- a/src/mist/io/static/js/dev.js
+++ b/src/mist/io/static/js/dev.js
@@ -27,6 +27,7 @@ require.config({
         d3: '../dist/d3/d3.min',
         c3: '../dist/c3/c3.min',
         term: '../dist/term.js/src/term',
+        yamljs: '../dist/yamljs/dist/yaml.min',
         init: 'init',
         common: 'common',
         multiplex: 'multiplex'


### PR DESCRIPTION
adds cloudinit support to GCE/Rackspace/Vultr
fixes an error with Vultr and locations
adds cloudinit validation on the frontend - checks if cloudinit is valid yaml, or if it starts with #!/bin/bash

First merge https://github.com/mistio/libcloud/pull/60