### PR TITLE
avoid DoesNotExist when querying a machine

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -2545,7 +2545,7 @@ def _machine_action(user, cloud_id, machine_id, action, plan_id=None, name=None)
                 else:
                     for key_assoc in machine.key_associations:
                         key_assoc.port = port
-                        machine.save()
+                    machine.save()
         elif action is 'stop':
             # In libcloud it is not possible to call this with machine.stop()
             if conn.type == 'azure':
@@ -2611,7 +2611,7 @@ def _machine_action(user, cloud_id, machine_id, action, plan_id=None, name=None)
                     else:
                         for key_assoc in machine.key_associations:
                             key_assoc.port = port
-                            machine.save()
+                        machine.save()
         elif action is 'destroy':
             if conn.type is Provider.DOCKER and node.state == 0:
                 conn.ex_stop_node(node)

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -9,7 +9,7 @@ import requests
 import subprocess
 import re
 import mongoengine as me
-from mongoengine import ValidationError, NotUniqueError
+from mongoengine import ValidationError, NotUniqueError, DoesNotExist
 from time import sleep, time
 from datetime import datetime
 from hashlib import sha256
@@ -2537,11 +2537,15 @@ def _machine_action(user, cloud_id, machine_id, action, plan_id=None, name=None)
                 except KeyError:
                     port = 22
 
-                machine = Machine.objects.get(cloud=cloud,
-                                              machine_id=machine_id)
-                for key_assoc in machine.key_associations:
-                    key_assoc.port = port
-                machine.save()
+                try:
+                    machine = Machine.objects.get(cloud=cloud,
+                                                  machine_id=machine_id)
+                except DoesNotExist:
+                    pass
+                else:
+                    for key_assoc in machine.key_associations:
+                        key_assoc.port = port
+                        machine.save()
         elif action is 'stop':
             # In libcloud it is not possible to call this with machine.stop()
             if conn.type == 'azure':
@@ -2598,12 +2602,16 @@ def _machine_action(user, cloud_id, machine_id, action, plan_id=None, name=None)
                         port = node_info.extra['network_settings']['Ports']['22/tcp'][0]['HostPort']
                     except KeyError:
                         port = 22
-                    machine = Machine.objects.get(cloud=cloud,
-                                                  machine_id=machine_id)
-                    for key_assoc in machine.key_associations:
-                        key_assoc.port = port
-                    machine.save()
 
+                    try:
+                        machine = Machine.objects.get(cloud=cloud,
+                                                      machine_id=machine_id)
+                    except DoesNotExist:
+                        pass
+                    else:
+                        for key_assoc in machine.key_associations:
+                            key_assoc.port = port
+                            machine.save()
         elif action is 'destroy':
             if conn.type is Provider.DOCKER and node.state == 0:
                 conn.ex_stop_node(node)


### PR DESCRIPTION
catch DoesNotExist in case machine object cannot be found in mongo.
update key_assoc only if machine is stored locally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/742)
<!-- Reviewable:end -->
