### PR TITLE
Minor fix to reduce chromedriver instabillity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ behaving==1.4.1
 celery==3.1.17
 gevent==1.0.2
 gevent-subprocess==0.1.1
+mongoengine==0.10.5
 netaddr==0.7.18
 paramiko==1.16.0
 PasteDeploy==1.5.2

--- a/src/mist/io/tests/helpers/selenium_utils.py
+++ b/src/mist/io/tests/helpers/selenium_utils.py
@@ -1,7 +1,12 @@
 import mist.io.tests.config as config
 
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+
+# chrome_options = Options()
+# chrome_options.add_argument('--dns-prefetch-disable')
+# driver = Chrome(chrome_options=options)
 
 import logging
 
@@ -21,9 +26,12 @@ def choose_driver(flavor=None):
             driver = webdriver.Firefox()
         elif flavor == "chrome":
             service_args = ['--verbose']
+            chrome_options = Options()
+            chrome_options.add_argument('--dns-prefetch-disable')
             driver = webdriver.Chrome(executable_path=config.WEBDRIVER_PATH,
                                       service_args=service_args,
-                                      service_log_path=config.WEBDRIVER_LOG)
+                                      service_log_path=config.WEBDRIVER_LOG,
+                                      chrome_options=chrome_options)
 
         elif flavor == "phantomjs":
             driver = webdriver.PhantomJS(executable_path=config.WEBDRIVER_PATH)

--- a/src/mist/io/tests/helpers/selenium_utils.py
+++ b/src/mist/io/tests/helpers/selenium_utils.py
@@ -4,10 +4,6 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
-# chrome_options = Options()
-# chrome_options.add_argument('--dns-prefetch-disable')
-# driver = Chrome(chrome_options=options)
-
 import logging
 
 log = logging.getLogger(__name__)
@@ -28,10 +24,10 @@ def choose_driver(flavor=None):
             service_args = ['--verbose']
             chrome_options = Options()
             chrome_options.add_argument('--dns-prefetch-disable')
-            driver = webdriver.Chrome(executable_path=config.WEBDRIVER_PATH,
-                                      service_args=service_args,
-                                      service_log_path=config.WEBDRIVER_LOG,
-                                      chrome_options=chrome_options)
+            driver = webdriver.Chrome(service_args=service_args,
+                                      chrome_options=chrome_options,
+                                      executable_path=config.WEBDRIVER_PATH,
+                                      service_log_path=config.WEBDRIVER_LOG)
 
         elif flavor == "phantomjs":
             driver = webdriver.PhantomJS(executable_path=config.WEBDRIVER_PATH)


### PR DESCRIPTION
There is a known issue since 2013 that when chromedriver can not find static content due to DNS errors then it might freeze or crash. This minor fix solves this issue which probably contributes to the chromedriver instabillity when tests are run locally with xvfb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/746)
<!-- Reviewable:end -->
