### PR TITLE
Prevent delete not empty team

### DIFF
--- a/src/mist/io/static/js/app/templates/organization_item.hbs
+++ b/src/mist/io/static/js/app/templates/organization_item.hbs
@@ -7,5 +7,5 @@
 {{/unless}}
 
 {{#if orgActive}}
-    <a href="#" class="ui-btn ui-btn-icon-left ui-mini {{if organization.id 'icon-teams' 'icon-team'}}">{{organization.name}}</a>
+    <a href="javascript:void(0)" class="ui-btn ui-btn-icon-left ui-mini {{if organization.id 'icon-teams' 'icon-team'}}">{{organization.name}}</a>
 {{/if}}

--- a/src/mist/io/static/js/app/templates/team.hbs
+++ b/src/mist/io/static/js/app/templates/team.hbs
@@ -110,7 +110,7 @@
                 <a class="ui-btn ui-btn-icon-right ui-caps icon-edit" {{action "renameClicked" target=view}}>Edit</a>
             </div>
             <div class="ui-block-b">
-                <a class="ui-btn ui-btn-icon-right ui-caps icon-xx" {{action "deleteClicked" target=view}}>Delete</a>
+                <a class="ui-btn ui-btn-icon-right ui-caps icon-xx {{if view.hasMembers 'ui-state-disabled'}}" {{action "deleteClicked" target=view}}>Delete</a>
             </div>
         </div>
     </div>

--- a/src/mist/io/static/js/app/views/team.js
+++ b/src/mist/io/static/js/app/views/team.js
@@ -80,28 +80,39 @@ define('app/views/team', ['app/views/page'],
                 },
 
                 deleteClicked: function() {
-                    var team = this.get('team');
+                    var team = this.get('team'),
+                    hasMembers = team.members.length > 0;
 
-                    Mist.dialogController.open({
-                        type: DIALOG_TYPES.YES_NO,
-                        head: 'Delete team',
-                        body: [{
-                            paragraph: 'Are you sure you want to delete team "' +
-                                team.name + '" ?'
-                        }],
-                        callback: function(didConfirm) {
-                            if (didConfirm) {
-                                Mist.teamsController.deleteTeam({
-                                    team: team,
-                                    callback: function(success) {
-                                        if (success) {
-                                            Mist.__container__.lookup('router:main').transitionTo('teams');
+                    if (hasMembers) {
+                        Mist.dialogController.open({
+                            type: DIALOG_TYPES.OK,
+                            head: 'Delete team',
+                            body: [{
+                                paragraph: 'Team ' + team.name + ' cannot be deleted. Remove its members first and try again!'
+                            }]
+                        });
+                    } else {
+                        Mist.dialogController.open({
+                            type: DIALOG_TYPES.YES_NO,
+                            head: 'Delete team',
+                            body: [{
+                                paragraph: 'Are you sure you want to delete team "' +
+                                    team.name + '" ?'
+                            }],
+                            callback: function(didConfirm) {
+                                if (didConfirm) {
+                                    Mist.teamsController.deleteTeam({
+                                        team: team,
+                                        callback: function(success) {
+                                            if (success) {
+                                                Mist.__container__.lookup('router:main').transitionTo('teams');
+                                            }
                                         }
-                                    }
-                                });
+                                    });
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 }
             },
 

--- a/src/mist/io/static/js/app/views/team.js
+++ b/src/mist/io/static/js/app/views/team.js
@@ -17,9 +17,13 @@ define('app/views/team', ['app/views/page'],
             // Computed Properties
             //
 
-            model: function () {
+            model: function() {
                 return this.get('controller').get('model');
             }.property('controller.model'),
+
+            hasMembers: Ember.computed('team.members.[]', function() {
+                return !!(this.get('team.members') && this.get('team.members').length);
+            }),
 
             //
             // Initialization
@@ -68,7 +72,9 @@ define('app/views/team', ['app/views/page'],
                 },
 
                 saveRulesClicked: function() {
-                    Mist.teamsController.saveRules({team: this.get('team')});
+                    Mist.teamsController.saveRules({
+                        team: this.get('team')
+                    });
                 },
 
                 addRulesClicked: function() {
@@ -80,39 +86,28 @@ define('app/views/team', ['app/views/page'],
                 },
 
                 deleteClicked: function() {
-                    var team = this.get('team'),
-                    hasMembers = team.members.length > 0;
+                    var team = this.get('team');
 
-                    if (hasMembers) {
-                        Mist.dialogController.open({
-                            type: DIALOG_TYPES.OK,
-                            head: 'Delete team',
-                            body: [{
-                                paragraph: 'Team "' + team.name + '" cannot be deleted. Remove its members first and try again!'
-                            }]
-                        });
-                    } else {
-                        Mist.dialogController.open({
-                            type: DIALOG_TYPES.YES_NO,
-                            head: 'Delete team',
-                            body: [{
-                                paragraph: 'Are you sure you want to delete team "' +
-                                    team.name + '" ?'
-                            }],
-                            callback: function(didConfirm) {
-                                if (didConfirm) {
-                                    Mist.teamsController.deleteTeam({
-                                        team: team,
-                                        callback: function(success) {
-                                            if (success) {
-                                                Mist.__container__.lookup('router:main').transitionTo('teams');
-                                            }
+                    Mist.dialogController.open({
+                        type: DIALOG_TYPES.YES_NO,
+                        head: 'Delete team',
+                        body: [{
+                            paragraph: 'Are you sure you want to delete team "' +
+                                team.name + '" ?'
+                        }],
+                        callback: function(didConfirm) {
+                            if (didConfirm) {
+                                Mist.teamsController.deleteTeam({
+                                    team: team,
+                                    callback: function(success) {
+                                        if (success) {
+                                            Mist.__container__.lookup('router:main').transitionTo('teams');
                                         }
-                                    });
-                                }
+                                    }
+                                });
                             }
-                        });
-                    }
+                        }
+                    });
                 }
             },
 

--- a/src/mist/io/static/js/app/views/team.js
+++ b/src/mist/io/static/js/app/views/team.js
@@ -88,7 +88,7 @@ define('app/views/team', ['app/views/page'],
                             type: DIALOG_TYPES.OK,
                             head: 'Delete team',
                             body: [{
-                                paragraph: 'Team ' + team.name + ' cannot be deleted. Remove its members first and try again!'
+                                paragraph: 'Team "' + team.name + '" cannot be deleted. Remove its members first and try again!'
                             }]
                         });
                     } else {

--- a/src/mist/io/static/js/app/views/team_list.js
+++ b/src/mist/io/static/js/app/views/team_list.js
@@ -99,23 +99,39 @@ define('app/views/team_list', ['app/views/page'],
                 },
 
                 deleteClicked: function() {
-                    var teams = Mist.teamsController.get('selectedObjects');
+                    var teams = Mist.teamsController.get('selectedObjects'),
+                    teamsWithMembers = teams.filter(function(team) {
+                        return team.members.length > 0;
+                    }), paragraph;
 
-                    Mist.dialogController.open({
-                        type: DIALOG_TYPES.YES_NO,
-                        head: 'Delete teams',
-                        body: [{
-                            paragraph: 'Are you sure you want to delete ' + (teams.length > 1 ? 'these teams: ' : 'this team: ') + teams.toStringByProperty('name') + ' ?'
-                        }],
-                        callback: function(didConfirm) {
-                            if (!didConfirm) return;
-                            teams.forEach(function(team) {
-                                Mist.teamsController.deleteTeam({
-                                    team: team
+                    if (teamsWithMembers.length > 0) {
+                        paragraph = teamsWithMembers.length > 1 ? 'Teams ' + teamsWithMembers.toStringByProperty('name') + ' cannot be deleted. Remove their members first and try again!'
+                         : 'Team ' + teamsWithMembers.toStringByProperty('name') + ' cannot be deleted. Remove its members first and try again!';
+
+                        Mist.dialogController.open({
+                            type: DIALOG_TYPES.OK,
+                            head: 'Delete teams',
+                            body: [{
+                                paragraph: paragraph
+                            }]
+                        });
+                    } else {
+                        Mist.dialogController.open({
+                            type: DIALOG_TYPES.YES_NO,
+                            head: 'Delete teams',
+                            body: [{
+                                paragraph: 'Are you sure you want to delete ' + (teams.length > 1 ? 'these teams: ' : 'this team: ') + teams.toStringByProperty('name') + ' ?'
+                            }],
+                            callback: function(didConfirm) {
+                                if (!didConfirm) return;
+                                teams.forEach(function(team) {
+                                    Mist.teamsController.deleteTeam({
+                                        team: team
+                                    });
                                 });
-                            });
-                        }
-                    });
+                            }
+                        });
+                    }
                 },
 
                 clearClicked: function() {

--- a/src/mist/io/static/js/app/views/team_list.js
+++ b/src/mist/io/static/js/app/views/team_list.js
@@ -30,7 +30,9 @@ define('app/views/team_list', ['app/views/page'],
             }),
 
             canDelete: Ember.computed('Mist.teamsController.model.@each.selected', function() {
-                return Mist.teamsController.get('selectedObjects').length;
+                return Mist.teamsController.get('selectedObjects').every(function(team) {
+                    return team.members && !team.members.length;
+                });
             }),
 
             //
@@ -99,39 +101,23 @@ define('app/views/team_list', ['app/views/page'],
                 },
 
                 deleteClicked: function() {
-                    var teams = Mist.teamsController.get('selectedObjects'),
-                    teamsWithMembers = teams.filter(function(team) {
-                        return team.members.length > 0;
-                    }), paragraph;
+                    var teams = Mist.teamsController.get('selectedObjects');
 
-                    if (teamsWithMembers.length > 0) {
-                        paragraph = teamsWithMembers.length > 1 ? 'Teams ' + teamsWithMembers.toStringByProperty('name') + ' cannot be deleted. Remove their members first and try again!'
-                         : 'Team ' + teamsWithMembers.toStringByProperty('name') + ' cannot be deleted. Remove its members first and try again!';
-
-                        Mist.dialogController.open({
-                            type: DIALOG_TYPES.OK,
-                            head: 'Delete teams',
-                            body: [{
-                                paragraph: paragraph
-                            }]
-                        });
-                    } else {
-                        Mist.dialogController.open({
-                            type: DIALOG_TYPES.YES_NO,
-                            head: 'Delete teams',
-                            body: [{
-                                paragraph: 'Are you sure you want to delete ' + (teams.length > 1 ? 'these teams: ' : 'this team: ') + teams.toStringByProperty('name') + ' ?'
-                            }],
-                            callback: function(didConfirm) {
-                                if (!didConfirm) return;
-                                teams.forEach(function(team) {
-                                    Mist.teamsController.deleteTeam({
-                                        team: team
-                                    });
+                    Mist.dialogController.open({
+                        type: DIALOG_TYPES.YES_NO,
+                        head: 'Delete teams',
+                        body: [{
+                            paragraph: 'Are you sure you want to delete ' + (teams.length > 1 ? 'these teams: ' : 'this team: ') + teams.toStringByProperty('name') + ' ?'
+                        }],
+                        callback: function(didConfirm) {
+                            if (!didConfirm) return;
+                            teams.forEach(function(team) {
+                                Mist.teamsController.deleteTeam({
+                                    team: team
                                 });
-                            }
-                        });
-                    }
+                            });
+                        }
+                    });
                 },
 
                 clearClicked: function() {

--- a/src/mist/io/static/main.css
+++ b/src/mist/io/static/main.css
@@ -1305,6 +1305,7 @@ ul.checkbox-list .ui-grid-b {
 .ui-popup ul.ui-listview li.organization-item.org-active a:hover:after {
     background-color: #009688 !important;
     color: #fff;
+    cursor: default;
 }
 
 .monitoring-dialog-container, .associate-key-container, .probe-dialog-container div {


### PR DESCRIPTION
when owner delete a team, check if team.members list  is empty
otherwise owner we delete teams and members will continue to be in the organization.members list

add checks at front/back end 

resolves https://github.com/mistio/mist.core/issues/1649

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/786)
<!-- Reviewable:end -->
