### PR TITLE
Ec2 images opt

### DIFF
--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -2913,6 +2913,9 @@ def list_images(user, cloud_id, term=None):
         elif conn.type in config.EC2_PROVIDERS and term:
             images = CloudImage.objects( me.Q(cloud_provider=conn.type, image_id__icontains=term) | me.Q(cloud_provider=conn.type, name__icontains=term))[:200]
             images = [NodeImage(id=image.image_id, name=image.name, driver=conn, extra={}) for image in images]
+            if not images:
+                # actual search on ec2
+                images = conn.list_images(ex_filters={'name': '*%s*' % term})
         elif conn.type == Provider.GCE:
             rest_images = conn.list_images()
             for gce_image in rest_images:

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -2895,7 +2895,6 @@ def list_images(user, cloud_id, term=None):
     the community images
 
     """
-
     cloud = Cloud.objects.get(owner=user, id=cloud_id)
     conn = connect_provider(cloud)
     try:
@@ -2911,9 +2910,9 @@ def list_images(user, cloud_id, term=None):
             for image in ec2_images:
                 image.name = config.EC2_IMAGES[conn.type].get(image.id, image.name)
             ec2_images += conn.list_images(ex_owner="self")
-            ec2_images += conn.list_images(ex_owner="amazon")
         elif conn.type in config.EC2_PROVIDERS and term:
-            ec2_images += conn.list_images()
+            images = CloudImage.objects( me.Q(cloud_provider=conn.type, image_id__icontains=term) | me.Q(cloud_provider=conn.type, name__icontains=term))[:200]
+            images = [NodeImage(id=image.image_id, name=image.name, driver=conn, extra={}) for image in images]
         elif conn.type == Provider.GCE:
             rest_images = conn.list_images()
             for gce_image in rest_images:
@@ -2943,12 +2942,12 @@ def list_images(user, cloud_id, term=None):
             starred_images = [image for image in rest_images
                               if image.id in starred]
 
-        images = starred_images + ec2_images + rest_images
-        images = [img for img in images
-                  if img.name and img.id[:3] not in ['aki', 'ari']
-                  and 'windows' not in img.name.lower()]
-
-        if term and term is not None:
+        if not term:
+            images = starred_images + ec2_images + rest_images
+            images = [img for img in images
+                      if img.name and img.id[:3] not in ['aki', 'ari']
+                      and 'windows' not in img.name.lower()]
+        elif term and term is not None:
             term = term.lower()
             if conn.type == Provider.LIBVIRT:
             # fetch a new listing of the images and search for the term
@@ -2956,10 +2955,7 @@ def list_images(user, cloud_id, term=None):
             elif conn.type == 'docker':
                 images = conn.search_images(term=term)[:100]
             #search directly on docker registry for the query
-            elif conn.type in config.EC2_PROVIDERS:
-                images = [img for img in images
-                          if term in img.id.lower()
-                          or img.name and term in img.name.lower()][:100]
+
     except Exception as e:
         log.error(repr(e))
         raise CloudUnavailableError(cloud_id, e)


### PR DESCRIPTION
-- current status on ec2 images: once you login, mist.io perform 3 queries to amazon, one of them takes 40 sec to complete (c.list_images(owner='amazon'). this brings 10000s of images on a random way (the default amis get first but all the other listings are totally random)
system gets too many images it cannot render, even if you search for an image it takes make seconds to render the results. the ui gets unresponsive and ec2 images seem to be #1 suspect for this.



--with this PR: it shows default ec2 amis only, plus starred and own images. thus returns quickly and shows images that you have chances to use and are not just random ec2 image (with a zero chance that you are willing to use) if you search an image and star it, you will always see it there afterwars. Star-ing an image can now be used 


--list_images API call now returns quick and the UI does not get endless images it cannot render. searching for an image takes place on the DB where images are stored, thus it returns in 1 sec. It will still perform an ec2 query if it cannot find any image on the DB

search on the DB is case insensitive against name and id 


tested that searching for images and staring them will return them the other times one logs in

ec2 images data is here: https://github.com/mistio/mist.core/pull/1964#issuecomment-225694014 and there's a script to update this that can be set as a procedure for updating images

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/841)
<!-- Reviewable:end -->
