### PR TITLE
Fix for bare_metal clouds

### DIFF
--- a/src/mist/io/bare_metal.py
+++ b/src/mist/io/bare_metal.py
@@ -68,7 +68,7 @@ class BareMetalDriver(object):
         return result in VALID_RESPONSE_CODES
 
     def _to_node(self, machine_id, machine):
-        hostname = machine.dns_name if machine.dns_name else machine.private_ips[0]
+        hostname = machine.dns_name or (machine.private_ips[0] if machine.private_ips else '')
         state = self.check_host(machine.cloud.owner, hostname, machine.ssh_port)
         extra = {}
         if hasattr(machine, 'os_type') and machine.os_type:


### PR DESCRIPTION
Addresses https://github.com/mistio/mist.core/issues/2088

Allows for bare metal machines to be displayed in the machines' list even when no hostname has been specified during 'Add Cloud'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/847)
<!-- Reviewable:end -->
