### PR TITLE
VPN to_tunnel method

### DIFF
--- a/src/mist/io/config.py
+++ b/src/mist/io/config.py
@@ -44,11 +44,6 @@ ALLOW_LIBVIRT_LOCALHOST = settings.get('ALLOW_LIBVIRT_LOCALHOST', False)
 # mist.io interface to the OpenVPN server
 VPN_SERVER_API_ADDRESS = settings.get('VPN_SERVER_API_ADDRESS', '')
 ALLOWED_PRIVATE_NETWORKS = settings.get('ALLOWED_PRIVATE_NETWORKS', ['192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8'])
-# list/range of private IPs to be excluded from VPN routing (docker-dev by default)
-EXCLUDED_PRIVATE_ADDRESSES = settings.get('EXCLUDED_PRIVATE_ADDRESSES', [])
-if os.environ.get("DOCKER_IP"):
-    EXCLUDED_PRIVATE_ADDRESSES.append(os.environ.get("DOCKER_IP"))
-# allow public addresses to be routed over VPN
 ALLOW_PUBLIC_VPN = settings.get('ALLOW_PUBLIC_VPN', True)
 
 # celery settings

--- a/src/mist/io/helpers.py
+++ b/src/mist/io/helpers.py
@@ -348,8 +348,7 @@ def extract_prefix(url, prefixes=['http://', 'https://']):
         return ''
 
 
-def check_host(host, allow_localhost=config.ALLOW_CONNECT_LOCALHOST,
-               allow_private=config.ALLOW_CONNECT_PRIVATE):
+def check_host(host, allow_localhost=config.ALLOW_CONNECT_LOCALHOST):
     """Check if a given host is a valid DNS name or IPv4 address"""
 
     try:
@@ -392,13 +391,11 @@ def check_host(host, allow_localhost=config.ALLOW_CONNECT_LOCALHOST,
         '255.255.255.255/32': ("reserved for the 'limited broadcast' "
                                "destination address"),
     }
+
     if not allow_localhost:
         forbidden_subnets['127.0.0.0/8'] = ("used for loopback addresses "
                                             "to the local host")
-    if not allow_private:
-        for cidr in ('10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'):
-            forbidden_subnets[cidr] = ("used for local communications "
-                                       "within a private network")
+
     cidr = netaddr.smallest_matching_cidr(ipaddr, forbidden_subnets.keys())
     if cidr:
         raise MistError("%s is not allowed. It belongs to '%s' "

--- a/src/mist/io/methods.py
+++ b/src/mist/io/methods.py
@@ -68,6 +68,9 @@ import mist.io.inventory
 
 from mist.core.vpn.methods import destination_nat as dnat
 from mist.core.vpn.methods import super_ping
+from mist.core.vpn.methods import to_tunnel
+
+from mist.core.exceptions import VPNTunnelError
 
 
 import logging
@@ -375,6 +378,12 @@ def _add_cloud_bare_metal(user, title, provider, params):
     except NotUniqueError:
         raise CloudExistsError()
 
+    try:
+        to_tunnel(user, machine_hostname)
+    except VPNTunnelError as err:
+        Cloud.objects.get(owner=user, id=cloud.id).delete()
+        raise err
+
     machine = Machine()
     machine.cloud = cloud
     machine_hostname = sanitize_host(machine_hostname)
@@ -454,6 +463,12 @@ def _add_cloud_coreos(user, title, provider, params):
         raise BadRequestError({"msg": e.message, "errors": e.to_dict()})
     except NotUniqueError:
         raise CloudExistsError()
+
+    try:
+        to_tunnel(user, machine_hostname)
+    except VPNTunnelError as err:
+        Cloud.objects.get(owner=user, id=cloud.id).delete()
+        raise err
 
     machine = Machine()
     machine.ssh_port = port

--- a/src/mist/io/sock.py
+++ b/src/mist/io/sock.py
@@ -26,7 +26,6 @@ try:
     from mist.core.cloud.models import Cloud, Machine
     from mist.core.keypair.models import Keypair
     from mist.core.vpn.models import Tunnel
-    from mist.core.vpn.methods import to_tunnel
     multi_user = True
 except ImportError:
     from mist.io import config

--- a/src/mist/io/sock.py
+++ b/src/mist/io/sock.py
@@ -26,7 +26,7 @@ try:
     from mist.core.cloud.models import Cloud, Machine
     from mist.core.keypair.models import Keypair
     from mist.core.vpn.models import Tunnel
-    from mist.core.vpn.methods import get_tunnel
+    from mist.core.vpn.methods import to_tunnel
     multi_user = True
 except ImportError:
     from mist.io import config
@@ -224,7 +224,7 @@ class MainConnection(MistConnection):
     def update_org(self):
         try:
             org = rbac_methods.filter_org(self.auth_context)
-        except: # Forbidden
+        except:  # Forbidden
             org = None
 
         if org:
@@ -360,24 +360,22 @@ class MainConnection(MistConnection):
                         continue
                     # machine just started running
                     self.running_machines.add(bmid)
+
                     ips = filter(lambda ip: ':' not in ip,
                                  machine.get('public_ips', []))
                     if not ips:
-                        # if not public IPs, search for private IPs with an
-                        # associated Tunnel, otherwise continue iterating over
-                        # the list of machines
+                        # if not public IPs, search for private IPs, otherwise
+                        # continue iterating over the list of machines
                         ips = filter(lambda ip: ':' not in ip,
                                      machine.get('private_ips', []))
-                        tunnel = get_tunnel(self.owner, ips[0])
-                        if not tunnel:
-                            if ips[0] not in ioconfig.EXCLUDED_PRIVATE_ADDRESSES:
-                                continue
+                        if not ips:
+                            continue
 
                     has_key = False
                     keypairs = Keypair.objects(owner=self.owner)
                     machine_obj = Machine.objects(cloud=cloud,
-                                          machine_id=machine["id"],
-                                          key_associations__not__size=0).first()
+                                                  machine_id=machine["id"],
+                                                  key_associations__not__size=0).first()
                     if machine_obj:
                         cached = tasks.ProbeSSH().smart_delay(
                             self.owner.id, cloud_id, machine['id'], ips[0]


### PR DESCRIPTION
Improve `core.vpn.methods.to_tunnel` method
1. Get rid of separate `get_tunnel` method
2. Perform ALLOW_CONNECT_PRIVATE check from within `to_tunnel`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistio/mist.io/849)
<!-- Reviewable:end -->
